### PR TITLE
Update qtpy to version 1.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  skip: True  # [ppc64le]
+  skip: True  # [py<36 or ppc64le]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -24,12 +24,13 @@ requirements:
     - wheel
 
   run:
-    - python
+    - python >=3.6
 
 test:
   requires:
     - pyqt
     - pip
+    - python <3.10
   imports:
   script:
     - QT_API=pyqt5 qtpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.10.0" %}
+{% set version = "1.11.0" %}
 
 package:
   name: qtpy
@@ -7,7 +7,7 @@ package:
 source:
   fn: qtpy-{{version}}.tar.gz
   url: https://pypi.io/packages/source/q/qtpy/QtPy-{{version}}.tar.gz
-  sha256: 3d20f010caa3b2c04835d6a2f66f8873b041bdaf7a76085c2a0d7890cdd65ea9
+  sha256: bbd61f8d6480a01cec39ad94249dbde7d0a8fce2aca61ff5037b645c4fd13e02
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   noarch: python
   number: 0
-  skip: True  # [py<36 or ppc64le]
+  # skip s390x due to pyqt missing on s390x
+  skip: True  # [py<36 or ppc64le or s390x]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION

1. check the upstream
https://github.com/spyder-ide/qtpy/tree/v1.10.0

2. check the pinnings
https://github.com/spyder-ide/qtpy/blob/v1.10.0/setup.py
https://github.com/spyder-ide/qtpy/blob/v1.10.0/setup.cfg

3. check changelogs
https://github.com/spyder-ide/qtpy/blob/v1.10.0/CHANGELOG.md

The changes mentioned in the changelog were bug fixes

4. additional research
https://github.com/conda-forge/qtpy-feedstock/issues

There are no open issues in conda forge for qtpy at the time of the review

5. verify dev_url
    https://github.com/spyder-ide/qtpy
6. verify doc_url
    https://pypi.python.org/pypi/QtPy
7. verify that pip is in the test section
8. verify the test section
9. additional tests


In order to test the `qtpy` package version `1.11.0` the following command was used:
`conda build qtpy-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research and on the test results we can conclude that it is safe to update `qtpy` to version `1.11.0`
