### PR TITLE
qtpy 2.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.11.2" %}
+{% set version = "2.0.1" %}
 
 package:
   name: qtpy
@@ -7,7 +7,7 @@ package:
 source:
   fn: qtpy-{{version}}.tar.gz
   url: https://pypi.io/packages/source/q/qtpy/QtPy-{{version}}.tar.gz
-  sha256: d6e4ae3a41f1fcb19762b58f35ad6dd443b4bdc867a4cb81ef10ccd85403c92b
+  sha256: adfd073ffbd2de81dc7aaa0b983499ef5c59c96adcfdcc9dea60d42ca885eb8f
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,27 +12,27 @@ source:
 build:
   noarch: python
   number: 0
-  # skip s390x due to pyqt missing on s390x
-  skip: True  # [py<36 or ppc64le or s390x]
-  script: python -m pip install --no-deps --ignore-installed .
+  # skip s390x and ppc64le due to pyqt missing on s390x and ppc64le
+  script: python -m pip install --no-deps --ignore-installed . -vv
 
 requirements:
 
   host:
     - pip
     - python
-    - setuptools
+    - setuptools >=42
     - wheel
-
   run:
     - python >=3.6
+    - packaging
 
 test:
   requires:
     - pyqt
     - pip
-    - python <3.10
   imports:
+    - qtpy
+    - qtpy.QtGui
   script:
     - QT_API=pyqt5 qtpy
     - QT_API=pyqt5 qtpy.QtGui


### PR DESCRIPTION
Update qtpy to 2.0.1

Bug tracker: https://github.com/conda-forge/qtpy-feedstock/issues
Changelog: https://github.com/spyder-ide/qtpy/blob/v2.0.1/CHANGELOG.md
Requirements:
- https://github.com/spyder-ide/qtpy/blob/v2.0.1/pyproject.toml
- https://github.com/spyder-ide/qtpy/blob/v2.0.1/setup.cfg

Actions:
1. Add pinning for setuptools >=42
2. Add packaging in run
3. Add test imports
